### PR TITLE
Allow include param on menus endpoint

### DIFF
--- a/web/wp-content/themes/twentytwentythree/functions.php
+++ b/web/wp-content/themes/twentytwentythree/functions.php
@@ -81,6 +81,11 @@ add_action( 'rest_api_init', function() {
           return is_numeric( $param );
         }
       ),
+      'include' => array(
+        'validate_callback' => function($param, $request, $key) {
+          return is_numeric( $param );
+        }
+      ),
     ),
   ) );
 


### PR DESCRIPTION
@bwaltz This PR just allows `include` as a parameter on the `menus` REST endpoint. The app makes an initial three HTTP calls for menus (site, arts banner, socials) which can be reduced to with `include` parameters for each menu.

I'm not yet on the platform backend org and don't have local repro on the backend setup so mostly PR'ing this to make sure it doesn't break the env for whatever reason.